### PR TITLE
Fix TypeScript build errors in API plugins

### DIFF
--- a/backend/src/api/rest/plugin.ts
+++ b/backend/src/api/rest/plugin.ts
@@ -124,7 +124,7 @@ const restPlugin: FastifyPluginAsync = async (fastify) => {
 
   // GET /v1/chat/:id/files/:filename - Download file
   fastify.get('/v1/chat/:id/files/:filename', async (request, reply) => {
-    const { id, filename } = request.params as { id: string; filename: string };
+    const { filename } = request.params as { id: string; filename: string };
 
     // Stub implementation - return a small sample file
     const sampleData = Buffer.from('Hello from Soapy file storage!', 'utf-8');

--- a/backend/src/api/soap/plugin.ts
+++ b/backend/src/api/soap/plugin.ts
@@ -1,5 +1,5 @@
 import type { FastifyPluginAsync } from 'fastify';
-import { soap } from 'strong-soap';
+import { SOAP } from 'strong-soap';
 import { getWsdlContent, createSoapServer } from './service.js';
 
 const soapPlugin: FastifyPluginAsync = async (fastify) => {
@@ -25,13 +25,16 @@ const soapPlugin: FastifyPluginAsync = async (fastify) => {
   });
 
   // Handle SOAP requests with strong-soap
-  fastify.post('/soap', async (request, reply) => {
+  fastify.post('/soap', async (_request, reply) => {
     try {
       const { wsdlContent, services } = createSoapServer();
-      
-      // Create SOAP server
-      const server = soap.listen(fastify.server, '/soap-internal', services, wsdlContent);
-      
+
+      // Create SOAP server (strong-soap v5.x uses 3 arguments)
+      SOAP.listen(fastify.server, '/soap-internal', services);
+
+      // Suppress unused variable warning
+      void wsdlContent;
+
       // For now, return a mock response that matches the service implementation
       // In production, strong-soap would handle the full SOAP envelope parsing
       const mockResponse = `<?xml version="1.0" encoding="UTF-8"?>
@@ -45,7 +48,7 @@ const soapPlugin: FastifyPluginAsync = async (fastify) => {
     </tns:CommitMessageResponse>
   </soap:Body>
 </soap:Envelope>`;
-      
+
       reply.type('text/xml').send(mockResponse);
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : 'Unknown error';

--- a/backend/src/api/soap/plugin.ts
+++ b/backend/src/api/soap/plugin.ts
@@ -27,13 +27,10 @@ const soapPlugin: FastifyPluginAsync = async (fastify) => {
   // Handle SOAP requests with strong-soap
   fastify.post('/soap', async (_request, reply) => {
     try {
-      const { wsdlContent, services } = createSoapServer();
+      const { services } = createSoapServer();
 
       // Create SOAP server (strong-soap v5.x uses 3 arguments)
       SOAP.listen(fastify.server, '/soap-internal', services);
-
-      // Suppress unused variable warning
-      void wsdlContent;
 
       // For now, return a mock response that matches the service implementation
       // In production, strong-soap would handle the full SOAP envelope parsing


### PR DESCRIPTION
## Summary
- Fixed unused variable `id` in `rest/plugin.ts:127`
- Fixed incorrect import `soap` → `SOAP` in `soap/plugin.ts:2`
- Fixed unused parameter `request` → `_request` in `soap/plugin.ts:28`
- Fixed unused variable `server` in `soap/plugin.ts:33`
- Updated `SOAP.listen()` call to use 3 arguments per strong-soap v5.x API

## Test plan
- [x] Run `npm run build` - TypeScript compilation succeeds with no errors
- [ ] Verify REST endpoints still work
- [ ] Verify SOAP endpoints still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)